### PR TITLE
CPR - 1251: add an api call throttling mechanism

### DIFF
--- a/google_api_calls.py
+++ b/google_api_calls.py
@@ -15,7 +15,7 @@ from config import Config
 
 
 def is_retryable(exception):
-    """funciton that returns whether the google api call error is a 429 error
+    """function that returns whether the google api call error is a 429 error
     so that the call could be retried"""
     return (
         isinstance(exception, requests.HTTPError)

--- a/google_api_calls.py
+++ b/google_api_calls.py
@@ -4,10 +4,30 @@ import json
 
 import requests
 from requests.exceptions import RequestException
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from config import Config
 
 
+def is_retryable(exception):
+    """funciton that returns whether the google api call error is a 429 error
+    so that the call could be retried"""
+    return (
+        isinstance(exception, requests.HTTPError)
+        and exception.response.status_code == 429
+    )
+
+
+@retry(
+    wait=wait_exponential(multiplier=1, min=5, max=10),
+    stop=stop_after_attempt(3),
+    retry=retry_if_exception_type(is_retryable),
+)
 def text_search(gp):
     """Function calling text search API"""
     gp_name = gp.name
@@ -27,17 +47,28 @@ def text_search(gp):
     }
     try:
         response = requests.post(
-            base_url, headers=params, data=json.dumps(body), timeout=10
+            base_url, headers=params, data=json.dumps(body), timeout=30
         )
         response.raise_for_status()
         data = response.json()
         return data.get("places", [])
+    except requests.HTTPError as http_error:
+        if http_error.response.status_code == 429:
+            raise http_error
+        raise RuntimeError(
+            f"google places API call HTTP error occured: {http_error}"
+        ) from http_error
     except RequestException as e:
         raise RuntimeError(
             f"google places API call failed: {e}"
         ) from e  # error log this
 
 
+@retry(
+    wait=wait_exponential(multiplier=1, min=5, max=10),
+    stop=stop_after_attempt(3),
+    retry=retry_if_exception_type(is_retryable),
+)
 def call_autocomplete(gp):
     """function calling the Autocomplete API"""
     gp_name = gp.name
@@ -67,6 +98,12 @@ def call_autocomplete(gp):
         response.raise_for_status()
         data = response.json()
         return data
+    except requests.HTTPError as http_error:
+        if http_error.response.status_code == 429:
+            raise http_error
+        raise RuntimeError(
+            f"google places API call HTTP error occured: {http_error}"
+        ) from http_error
     except RequestException as e:
         raise RuntimeError(
             f"google places API call failed: {e}"

--- a/main.py
+++ b/main.py
@@ -87,8 +87,8 @@ def process_gp(giving_partner, session):
         return
     try:
         text_search_results = text_search(giving_partner)
-    except RuntimeError as e:
-        print(f"{e}")  # error log this
+    except Exception as e:
+        print(f"Error calling google text search API: {e}")  # error log this
         raise
     if len(text_search_results) > 0:
         # get the topmost result from the text search assuming it is the right GP

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ rapidfuzz
 dotenv
 givelifylogging @ git+https://github.com/Givelify/structured-logging-python-package.git
 sqlalchemy
+tenacity


### PR DESCRIPTION
Added retry decorator from tenacity above the api call functions and try excepts inside the functions to handle retrying the API calls appropriately in case of 429s